### PR TITLE
Make the navigation site aware

### DIFF
--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -49,6 +49,12 @@ class MenuContentAdmin(admin.ModelAdmin):
     list_display = ["title", "get_menuitem_link", "get_preview_link"]
     list_display_links = None
 
+    def get_queryset(self, request):
+        queryset = super().get_queryset(request)
+        queryset = queryset.prefetch_related('menu').filter(
+            menu__site=get_current_site(request))
+        return queryset
+
     def save_model(self, request, obj, form, change):
         if not change:
             title = form.cleaned_data.get("title")

--- a/tests/settings.py
+++ b/tests/settings.py
@@ -22,6 +22,12 @@ HELPER_SETTINGS = {
         'djangocms_version_locking': None,
         'djangocms_moderation': None,
     },
+    "LANGUAGES": (
+        ("en", "English"),
+        ("de", "German"),
+        ("fr", "French"),
+        ("it", "Italiano"),
+    ),
 }
 
 


### PR DESCRIPTION
The admin should only show navigation menus that are for the current site. Tests are required to enforce the requirement in the future.