### PR TITLE
 Version locked items can't be moved or changed - cherrypicked

### DIFF
--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -29,6 +29,17 @@ try:
 except ImportError:
     pass
 
+try:
+    from djangocms_version_locking.helpers import content_is_unlocked_for_user
+    using_version_lock = True
+    LOCK_MESSAGE = _(
+        "The item is currently locked or you don't "
+        "have permission to change it"
+    )
+except ImportError:
+    using_version_lock = False
+    LOCK_MESSAGE = _("You don't have permission to change this item")
+
 
 class MenuItemChangeList(ChangeList):
     def __init__(self, request, *args, **kwargs):
@@ -165,22 +176,29 @@ class MenuItemAdmin(TreeAdmin):
         extra_context = extra_context or {}
         if menu_content_id:
             request.menu_content_id = menu_content_id
-            if self._versioning_enabled:
-                menu_content = get_object_or_404(
-                    MenuContent._base_manager, id=menu_content_id
-                )
-                version = Version.objects.get_for_content(menu_content)
-                try:
-                    version.check_modify(request.user)
-                except ConditionFailed as error:
-                    messages.error(request, str(error))
-                    return HttpResponseRedirect(version_list_url(menu_content))
-                # purge menu cache
-                purge_menu_cache(site_id=menu_content.menu.site_id)
-            extra_context["list_url"] = reverse(
-                "admin:djangocms_navigation_menuitem_list",
-                kwargs={"menu_content_id": menu_content_id},
+
+        if self._versioning_enabled:
+            menu_content = get_object_or_404(
+                self.MenuModel._base_manager, id=menu_content_id
             )
+
+            change_perm = self.has_change_permission(request, menu_content)
+            if not change_perm:
+                messages.error(request, 'You don\'t have permission to edit or it is locked')
+                return HttpResponseRedirect(version_list_url(menu_content))
+
+            version = Version.objects.get_for_content(menu_content)
+            try:
+                version.check_modify(request.user)
+            except ConditionFailed as error:
+                messages.error(request, str(error))
+                return HttpResponseRedirect(version_list_url(menu_content))
+            # purge menu cache
+            purge_menu_cache(site_id=menu_content.menu.site_id)
+        extra_context["list_url"] = reverse(
+            self.get_admin_name('list', reverse=True),
+            kwargs={"menu_content_id": menu_content_id},
+        )
 
         return super().change_view(
             request, object_id, form_url="", extra_context=extra_context
@@ -249,6 +267,12 @@ class MenuItemAdmin(TreeAdmin):
             menu_content = get_object_or_404(
                 MenuContent._base_manager, id=menu_content_id
             )
+            request.menu_content_id = menu_content_id
+            change_perm = self.has_change_permission(request, menu_content)
+            if not change_perm:
+                messages.error(request, LOCK_MESSAGE)
+                return HttpResponseBadRequest(LOCK_MESSAGE)
+
             version = Version.objects.get_for_content(menu_content)
             try:
                 version.check_modify(request.user)
@@ -272,6 +296,12 @@ class MenuItemAdmin(TreeAdmin):
     def has_change_permission(self, request, obj=None):
         if not hasattr(request, "menu_content_id"):
             return False
+
+        if obj and using_version_lock:
+            unlocked = content_is_unlocked_for_user(obj, request.user)
+            if not unlocked:
+                return False
+
         return super().has_change_permission(request, obj)
 
     def get_changelist(self, request, **kwargs):

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -17,7 +17,7 @@ from treebeard.admin import TreeAdmin
 from .constants import SELECT2_CONTENT_OBJECT_URL_NAME
 from .forms import MenuContentForm, MenuItemForm
 from .models import Menu, MenuContent, MenuItem
-from .utils import purge_menu_cache
+from .utils import purge_menu_cache, reverse_admin_name
 from .views import ContentObjectSelect2View, MenuContentPreviewView
 
 
@@ -179,12 +179,12 @@ class MenuItemAdmin(TreeAdmin):
 
         if self._versioning_enabled:
             menu_content = get_object_or_404(
-                self.MenuModel._base_manager, id=menu_content_id
+                MenuContent._base_manager, id=menu_content_id
             )
 
             change_perm = self.has_change_permission(request, menu_content)
             if not change_perm:
-                messages.error(request, 'You don\'t have permission to edit or it is locked')
+                messages.error(request, LOCK_MESSAGE)
                 return HttpResponseRedirect(version_list_url(menu_content))
 
             version = Version.objects.get_for_content(menu_content)
@@ -195,8 +195,9 @@ class MenuItemAdmin(TreeAdmin):
                 return HttpResponseRedirect(version_list_url(menu_content))
             # purge menu cache
             purge_menu_cache(site_id=menu_content.menu.site_id)
-        extra_context["list_url"] = reverse(
-            self.get_admin_name('list', reverse=True),
+        extra_context["list_url"] = reverse_admin_name(
+            self.model,
+            'list',
             kwargs={"menu_content_id": menu_content_id},
         )
 

--- a/djangocms_navigation/utils.py
+++ b/djangocms_navigation/utils.py
@@ -2,8 +2,24 @@ from functools import lru_cache
 
 from django.apps import apps
 from django.contrib.contenttypes.models import ContentType
+from django.urls import reverse
 
 from menus.menu_pool import menu_pool
+
+
+def get_admin_name(model, name):
+    name = '{}_{}_{}'.format(
+        model._meta.app_label,
+        model._meta.model_name,
+        name
+    )
+    return name
+
+
+def reverse_admin_name(model, name, args=None, kwargs=None):
+    name = get_admin_name(model, name)
+    url = reverse('admin:{}'.format(name), args=args, kwargs=kwargs)
+    return url
 
 
 @lru_cache(maxsize=1)

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,5 +1,6 @@
 from unittest.mock import patch
 
+from django.contrib.messages import get_messages
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
@@ -175,12 +176,66 @@ class MenuItemModelAdminTestCase(TestCase):
         )
 
 
+class MenuItemAdminVersionLocked(CMSTestCase, UsefulAssertsMixin):
+
+    def setUp(self):
+        # who is author..
+        self.menu_content = factories.MenuContentWithVersionFactory(version__state=DRAFT)
+        self.item = factories.ChildMenuItemFactory(parent=self.menu_content.root)
+
+        self.change_url = reverse(
+            "admin:djangocms_navigation_menuitem_change",
+            kwargs={"menu_content_id": self.menu_content.pk, "object_id": self.item.pk}
+        )
+        self.client.force_login(self.get_superuser())
+
+        # moving a node
+        menu_content = factories.MenuContentWithVersionFactory()
+        self.child = factories.ChildMenuItemFactory(parent=menu_content.root)
+        self.child_of_child = factories.ChildMenuItemFactory(parent=self.child)
+        self.move_url = reverse(
+            "admin:djangocms_navigation_menuitem_move_node", args=(menu_content.id,)
+        )
+        self.data = {
+            "node_id": self.child_of_child.pk,
+            "sibling_id": menu_content.root.pk,
+            "as_child": 1,
+        }
+
+    def test_visit_change_view_when_node_is_version_locked_fails(self):
+        """It fails as super user is not the person who created the version"""
+        response = self.client.get(self.change_url)
+        msg = list(get_messages(response.wsgi_request))[0]
+
+        self.assertEquals(msg.message, "You don't have permission to edit or it is locked")
+        self.assertEquals(response.status_code, 302)
+
+    def test_moving_node_that_is_version_locked_fails(self):
+        response = self.client.post(self.move_url, data=self.data)
+        content = response.content.decode('utf-8')
+        msg = "The item is currently locked or you don't have permission to change it"
+
+        self.assertEquals(response.status_code, 400)
+        self.assertEquals(content, msg)
+
+    @patch('djangocms_navigation.admin.using_version_lock', False)
+    def test_moving_node_version_lock_not_installed_works_without_error(self):
+        response = self.client.post(self.move_url, data=self.data)
+
+        self.assertEquals(response.status_code, 200)
+        self.child.refresh_from_db()
+        self.child_of_child.refresh_from_db()
+        self.assertTrue(self.child_of_child.is_sibling_of(self.child))
+
+
 class MenuItemAdminChangeViewTestCase(CMSTestCase, UsefulAssertsMixin):
     def setUp(self):
         self.client.force_login(self.get_superuser())
 
     def test_menuitem_change_view(self):
-        menu_content = factories.MenuContentWithVersionFactory(version__state=DRAFT)
+        menu_content = factories.MenuContentWithVersionFactory(
+            version__state=DRAFT, version__created_by=self.get_superuser()
+        )
         item = factories.ChildMenuItemFactory(parent=menu_content.root)
         change_url = reverse(
             "admin:djangocms_navigation_menuitem_change",
@@ -278,7 +333,9 @@ class MenuItemAdminChangeViewTestCase(CMSTestCase, UsefulAssertsMixin):
         mocked_check.side_effect = ConditionFailed(
             "Go look at some cat pictures instead"
         )
-        menu_content = factories.MenuContentWithVersionFactory()
+        menu_content = factories.MenuContentWithVersionFactory(
+            version__created_by=self.get_superuser()
+        )
         item = factories.ChildMenuItemFactory(parent=menu_content.root)
         change_url = reverse(
             "admin:djangocms_navigation_menuitem_change",
@@ -636,10 +693,11 @@ class MenuItemAdminChangeListViewTestCase(CMSTestCase, UsefulAssertsMixin):
 
 class MenuItemAdminMoveNodeViewTestCase(CMSTestCase):
     def setUp(self):
-        self.client.force_login(self.get_superuser())
+        self.user = self.get_superuser()
+        self.client.force_login(self.user)
 
     def test_menuitem_move_node_smoke_test(self):
-        menu_content = factories.MenuContentWithVersionFactory()
+        menu_content = factories.MenuContentWithVersionFactory(version__created_by=self.user)
         child = factories.ChildMenuItemFactory(parent=menu_content.root)
         child_of_child = factories.ChildMenuItemFactory(parent=child)
         move_url = reverse(
@@ -660,7 +718,7 @@ class MenuItemAdminMoveNodeViewTestCase(CMSTestCase):
 
     @patch("django.contrib.messages.error")
     def test_menuitem_move_node_cant_move_outside_of_root(self, mocked_messages):
-        menu_content = factories.MenuContentWithVersionFactory()
+        menu_content = factories.MenuContentWithVersionFactory(version__created_by=self.user)
         child = factories.ChildMenuItemFactory(parent=menu_content.root)
         move_url = reverse(
             "admin:djangocms_navigation_menuitem_move_node", args=(menu_content.id,)
@@ -702,7 +760,7 @@ class MenuItemAdminMoveNodeViewTestCase(CMSTestCase):
         mocked_check.side_effect = ConditionFailed(
             "Go look at some cat pictures instead"
         )
-        menu_content = factories.MenuContentWithVersionFactory()
+        menu_content = factories.MenuContentWithVersionFactory(version__created_by=self.user)
         child = factories.ChildMenuItemFactory(parent=menu_content.root)
         child_of_child = factories.ChildMenuItemFactory(parent=child)
         move_url = reverse(

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1,8 +1,8 @@
 from unittest.mock import patch
 
-from django.contrib.messages import get_messages
 from django.contrib import admin
 from django.contrib.contenttypes.models import ContentType
+from django.contrib.messages import get_messages
 from django.contrib.sites.models import Site
 from django.shortcuts import reverse
 from django.test import RequestFactory, TestCase
@@ -179,7 +179,6 @@ class MenuItemModelAdminTestCase(TestCase):
 class MenuItemAdminVersionLocked(CMSTestCase, UsefulAssertsMixin):
 
     def setUp(self):
-        # who is author..
         self.menu_content = factories.MenuContentWithVersionFactory(version__state=DRAFT)
         self.item = factories.ChildMenuItemFactory(parent=self.menu_content.root)
 
@@ -207,7 +206,7 @@ class MenuItemAdminVersionLocked(CMSTestCase, UsefulAssertsMixin):
         response = self.client.get(self.change_url)
         msg = list(get_messages(response.wsgi_request))[0]
 
-        self.assertEquals(msg.message, "You don't have permission to edit or it is locked")
+        self.assertEquals(msg.message, "The item is currently locked or you don't have permission to change it")
         self.assertEquals(response.status_code, 302)
 
     def test_moving_node_that_is_version_locked_fails(self):


### PR DESCRIPTION
Cherrypicked changes explicitly to fix this issue from #51 