### PR TITLE
Fixed an issue with the admin menu edit button redirect 

### DIFF
--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -198,13 +198,13 @@ class MenuContentAdmin(admin.ModelAdmin):
             disabled = True
 
         url = reverse(
-            "admin:{app}_{model}_list".format(
-                app=obj._meta.app_label, model=self.menu_item_model._meta.model_name
+            "admin:{app}_{model}_edit_redirect".format(
+                app=version._meta.app_label, model=version._meta.model_name
             ),
-            args=[obj.pk],
+            args=(version.pk,),
         )
         return render_to_string(
-            "djangocms_versioning/admin/edit_icon.html",
+            "djangocms_navigation/admin/icons/edit_icon.html",
             {"url": url, "disabled": disabled, "post": False},
         )
 

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -1,5 +1,3 @@
-from copy import deepcopy
-
 from django.apps import apps
 from django.conf.urls import url
 from django.contrib import admin, messages
@@ -15,12 +13,12 @@ from django.utils.text import slugify
 from django.utils.translation import ugettext_lazy as _
 from django.views.i18n import JavaScriptCatalog
 
-from djangocms_versioning import versionables
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from treebeard.admin import TreeAdmin
 
 from .filters import LanguageFilter
 from .forms import MenuContentForm, MenuItemForm
+from .helpers import proxy_model
 from .models import Menu, MenuContent, MenuItem
 from .utils import is_versioning_enabled, purge_menu_cache, reverse_admin_name
 from .views import ContentObjectSelect2View, MenuContentPreviewView
@@ -43,13 +41,6 @@ try:
 except ImportError:
     using_version_lock = False
     LOCK_MESSAGE = _("You don't have permission to change this item")
-
-
-def proxy_model(obj):
-    versionable = versionables.for_content(MenuContent)
-    obj_ = deepcopy(obj)
-    obj_.__class__ = versionable.version_model_proxy
-    return obj_
 
 
 class MenuItemChangeList(ChangeList):
@@ -188,7 +179,7 @@ class MenuContentAdmin(admin.ModelAdmin):
         :param disabled: Should the link be marked disabled?
         :return: Preview icon template
         """
-        version = proxy_model(self.get_version(obj))
+        version = proxy_model(self.get_version(obj), self.model)
 
         if version.state not in (DRAFT, PUBLISHED):
             # Don't display the link if it can't be edited

--- a/djangocms_navigation/forms.py
+++ b/djangocms_navigation/forms.py
@@ -40,7 +40,7 @@ class MenuContentForm(forms.ModelForm):
 class Select2Mixin:
     class Media:
         css = {"all": ("cms/js/select2/select2.css",)}
-        js = ("cms/js/select2/select2.js", "djangocms_navigation/js/create_url.js")
+        js = ("admin/js/jquery.init.js", "cms/js/select2/select2.js", "djangocms_navigation/js/create_url.js")
 
 
 class ContentTypeObjectSelectWidget(Select2Mixin, forms.TextInput):

--- a/djangocms_navigation/helpers.py
+++ b/djangocms_navigation/helpers.py
@@ -1,4 +1,8 @@
+from copy import deepcopy
+
 from django.contrib.contenttypes.models import ContentType
+
+from djangocms_versioning import versionables
 
 from .models import MenuItem
 
@@ -22,3 +26,16 @@ def get_navigation_node_for_content_object(menu_content, content_object, node_mo
             return search_node
 
     return False
+
+
+def proxy_model(obj, content_model):
+    """
+    Get the proxy model from a
+
+    :param obj: A registered versionable object
+    :param content_model: A registered content model
+    """
+    versionable = versionables.for_content(content_model)
+    obj_ = deepcopy(obj)
+    obj_.__class__ = versionable.version_model_proxy
+    return obj_

--- a/djangocms_navigation/templates/djangocms_navigation/admin/icons/edit_icon.html
+++ b/djangocms_navigation/templates/djangocms_navigation/admin/icons/edit_icon.html
@@ -1,0 +1,5 @@
+{% extends "./base.html" %}
+{% load static i18n %}
+{% block title %}{% trans 'Edit' %}{% endblock %}
+{% block name %}edit{% endblock %}
+{% block icon %}{% static 'djangocms_navigation/svg/edit.svg' %}{% endblock %}


### PR DESCRIPTION
Fixes #75 
- The admin edit button fixed by ensuring that the correct endpoint is used and the template loads correctly
- Moved the proxy model to a helper and allow it to be used by packages that extend the navigation
- The JS is loaded in the correct order for Django 2.2: https://docs.djangoproject.com/en/3.0/releases/2.2/#merging-of-form-media-assets
- Amended the tests to cover the functionality