### PR TITLE
Feature: Added list action edit button for MenuItems

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,10 @@ Changelog
 
 Unreleased
 ==========
+* MenuItem edit button added as list action button
 
 1.0.0 (2022-02-18)
 ===================
-* MenuItem edit button added as list action button
 * MenuItem delete moved from dropdown action to individual delete action button
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ Unreleased
 
 1.0.0 (2022-02-18)
 ===================
+* MenuItem edit button added as list action button
 * MenuItem delete moved from dropdown action to individual delete action button
 * Python 3.8, 3.9 support added
 * Django 3.0, 3.1 and 3.2 support added

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -397,8 +397,22 @@ class MenuItemAdmin(TreeAdmin):
         Collect rendered actions from implemented methods and return as list
         """
         return [
+            self._get_edit_link,
             self._get_delete_link,
         ]
+
+    def _get_edit_link(self, obj, request, disabled=False):
+        app, model = self.model._meta.app_label, self.model._meta.model_name
+
+        edit_url = reverse(
+            "admin:{app}_{model}_change".format(app=app, model=model),
+            args=[request.menu_content_id, obj.id]
+        )
+
+        return render_to_string(
+            "djangocms_versioning/admin/edit_icon.html",
+            {"edit_url": edit_url, "disabled": disabled, "object_id": obj.id}
+        )
 
     def _get_delete_link(self, obj, request, disabled=False):
         app, model = self.model._meta.app_label, self.model._meta.model_name

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1362,7 +1362,7 @@ class MenuItemPermissionTestCase(CMSTestCase):
         self.assertFalse(model_admin.has_change_permission(request))
 
 
-class ListActionsTestCase(CMSTestCase):
+class MenuListActionsTestCase(CMSTestCase):
     def setUp(self):
         self.modeladmin = admin.site._registry[MenuContent]
 
@@ -1416,3 +1416,25 @@ class ListActionsTestCase(CMSTestCase):
         response = func(version.content)
 
         self.assertNotIn("cms-versioning-action-edit ", response)
+
+
+class MenuItemListActionsTestCase(CMSTestCase):
+    def setUp(self):
+        self.modeladmin = admin.site._registry[MenuItem]
+
+    def test_edit_link(self):
+        user = self.get_superuser()
+        menu_content = factories.MenuContentWithVersionFactory(version__created_by=user)
+        request = self.get_request("/")
+        request.user = self.get_superuser()
+        request.menu_content_id = menu_content.pk
+
+        func = self.modeladmin._list_actions(request)
+        edit_endpoint = reverse(
+            "admin:djangocms_navigation_menuitem_change", args=(menu_content.pk, menu_content.root.pk),
+        )
+        response = func(menu_content.root)
+
+        self.assertIn("cms-versioning-action-btn", response)
+        self.assertIn('title="Edit"', response)
+        self.assertIn(edit_endpoint, response)


### PR DESCRIPTION
Added Edit icon button to MenuItem list actions menu. This makes use of the existing change_view implementation for MenuItem, therefore the only additional tests added are for the action button.