### PR TITLE
Release 1.0.1

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,10 @@ Changelog
 
 Unreleased
 ==========
+
+
+1.0.1 (2022-03-01)
+===================
 * feat: MenuContent dropdown actions removed
 * feat: MenuItem edit button added as list action button
 * feat: Hide the MenuItem boolean false icon for `Hide in Menu` and `Soft Root` fields.

--- a/djangocms_navigation/__init__.py
+++ b/djangocms_navigation/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.0.0"
+__version__ = "1.0.1"
 
 default_app_config = "djangocms_navigation.apps.NavigationConfig"


### PR DESCRIPTION
* feat: MenuContent dropdown actions removed
* feat: MenuItem edit button added as list action button
* feat: Hide the MenuItem boolean false icon for `Hide in Menu` and `Soft Root` fields.
* feat: MenuItem changelist admin, remove the option to sort by `Hide In Menu` and `Soft Root`.