### PR TITLE
Effectively removing pagination for changelist view.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: Removed pagination in MenuItem changelist view by max-ing the list_per_page value.
 
 1.0.5 (2022-03-24)
 ==================

--- a/djangocms_navigation/admin.py
+++ b/djangocms_navigation/admin.py
@@ -1,6 +1,8 @@
 import json
+import sys
 
 from django.apps import apps
+from django.conf import settings
 from django.contrib import admin, messages
 from django.contrib.admin.options import IS_POPUP_VAR
 from django.contrib.admin.templatetags.admin_urls import add_preserved_filters
@@ -21,7 +23,6 @@ from django.views.i18n import JavaScriptCatalog
 from djangocms_versioning.constants import DRAFT, PUBLISHED
 from treebeard.admin import TreeAdmin
 
-from .constants import MAX_RESULTS_PER_PAGE
 from .filters import LanguageFilter
 from .forms import MenuContentForm, MenuItemForm
 from .helpers import proxy_model
@@ -55,6 +56,9 @@ try:
 except ImportError:
     using_version_lock = False
     LOCK_MESSAGE = _("You don't have permission to change this item")
+
+# This setting is used to effectively disable django pagination for MenuItem changelist view:
+MAX_RESULTS_PER_PAGE = getattr(settings, "MAX_RESULTS_PER_PAGE", sys.maxsize)
 
 
 class MenuItemChangeList(ChangeList):

--- a/djangocms_navigation/constants.py
+++ b/djangocms_navigation/constants.py
@@ -1,5 +1,3 @@
-import sys
-
 from django.conf import settings
 from django.utils.translation import gettext_lazy as _
 
@@ -28,6 +26,3 @@ PLUGIN_URL_NAME_PREFIX = "djangocms_navigation"
 SELECT2_CONTENT_OBJECT_URL_NAME = "{}_select2_content_object".format(
     PLUGIN_URL_NAME_PREFIX
 )
-
-# Used to effectively disable django admin pagination:
-MAX_RESULTS_PER_PAGE = sys.maxsize


### PR DESCRIPTION
Disabled the pagination in MenuItem changelist view by setting the list_per_page to max value. This was desired to allow the full result set to display on one page.

