### PR TITLE
Release 1.5.0

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,10 +4,13 @@ Changelog
 
 Unreleased
 ==========
+
+1.5.0 (2022-08-22)
+==================
 * feat: Improved MenuItemAdmin preview_view to allow the user to view the full navigation tree
 and use expand/collapse commands for all nodes in the tree.
 * feat: Button to switch to edit mode when viewing a navigation menu in preview.
-* fix: Added CMS_CONFIRM_VERSION4 in test_settings to show intend of using v4
+* fix: Added CMS_CONFIRM_VERSION4 in test_settings to show intent of using v4
 
 1.4.0 (2022-08-12)
 ==================

--- a/djangocms_navigation/__init__.py
+++ b/djangocms_navigation/__init__.py
@@ -1,3 +1,3 @@
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 
 default_app_config = "djangocms_navigation.apps.NavigationConfig"


### PR DESCRIPTION
* feat: Improved MenuItemAdmin preview_view to allow the user to view the full navigation tree
and use expand/collapse commands for all nodes in the tree.
* feat: Button to switch to edit mode when viewing a navigation menu in preview.
* fix: Added CMS_CONFIRM_VERSION4 in test_settings to show intent of using v4 https://github.com/django-cms/django-cms/commit/ff6cb9b5dced92eadef62694e989d601e9475b30