### PR TITLE
Feature/add menu item distinct nodes

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,7 @@ Changelog
 Unreleased
 ==========
 * fix: Remove duplicate objects when adding MenuItem nodes
+* feat: When adding a MenuItem the Page objects are filtered for the current site and language
 
 1.5.0 (2022-08-22)
 ==================

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Remove duplicate objects when adding MenuItem nodes
 
 1.5.0 (2022-08-22)
 ==================

--- a/djangocms_navigation/cms_config.py
+++ b/djangocms_navigation/cms_config.py
@@ -93,7 +93,7 @@ class NavigationCMSAppConfig(CMSAppConfig):
     )
     navigation_models = {
         # model_class : field(s) to search in menu item form UI
-        Page: ["title"]
+        Page: ["pagecontent_set__title__icontains"]
     }
     djangocms_references_enabled = True
     reference_fields = [

--- a/djangocms_navigation/views.py
+++ b/djangocms_navigation/views.py
@@ -5,6 +5,7 @@ from django.http import HttpResponseBadRequest, JsonResponse
 from django.views.generic import View
 
 from cms.models import Page
+from cms.utils import get_language_from_request
 
 from djangocms_navigation.utils import is_model_supported, supported_models
 
@@ -67,10 +68,13 @@ class ContentObjectSelect2View(View):
         if not query:
             return queryset
 
-        # TODO: filter by language and publish state
+        # TODO: filter by publish state
         # For Page model filter query by pagecontent title
         if model == Page:
-            return queryset.filter(pagecontent_set__title__icontains=query).distinct()
+            language = get_language_from_request(self.request)
+            return queryset.filter(
+                pagecontent_set__title__icontains=query, pagecontent_set__language=language
+            ).distinct()
 
         # Non page model should work using filter against field in queryset
         search_fields = supported_models(self.menu_content_model).get(model)

--- a/djangocms_navigation/views.py
+++ b/djangocms_navigation/views.py
@@ -78,6 +78,10 @@ class ContentObjectSelect2View(View):
                     for field in search_fields:
                         options[field] = query
                     queryset = queryset.filter(**options)
+            # if we have a search query we call distinct as for a Page this results in an SQL join due to the filter
+            # being across the reverse FK relation to pagecontent_set. This may also be the case for other content types
+            # so the distinct() call is included whenever we have a search query.
+            queryset = queryset.distinct()
 
         return queryset
 

--- a/tests/test_cms_config.py
+++ b/tests/test_cms_config.py
@@ -75,7 +75,7 @@ class NavigationIntegrationTestCase(TestCase):
             TestModel2: [],
             TestModel3: [],
             TestModel4: [],
-            Page: ["title"],
+            Page: ["pagecontent_set__title__icontains"],
             PollContent: ["text"],
         }
         self.assertDictEqual(registered_models, expected_models)

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -434,7 +434,7 @@ class ContentObjectSelect2ViewGetDataTestCase(CMSTestCase):
     @patch("djangocms_navigation.views.get_current_site")
     def test_page_queryset_filtered_by_site(self, mock_get_current_site):
         """
-        Check that when pages belong to different sites, only sites for
+        Check that when pages belong to different sites, the returned queryset only includes pages for the current site
         """
         site1 = Site.objects.create(domain="site1.com", name="site1")
         site2 = Site.objects.create(domain="site2.com", name="site2")
@@ -447,11 +447,10 @@ class ContentObjectSelect2ViewGetDataTestCase(CMSTestCase):
                 mock_get_current_site.return_value = site
                 results = self.view.get_data()
 
-                expected = results.values_list("node__site__domain", flat=True).distinct()
+                expected_domain = results.values_list("node__site__domain", flat=True).distinct()
                 self.assertEqual(Page._base_manager.count(), 20)
                 self.assertEqual(results.count(), 10)
-                self.assertEqual(expected.count(), 1)
-                self.assertEqual(expected.first(), site.domain)
+                self.assertEqual(expected_domain.first(), site.domain)
 
     def test_when_no_site_param_get_current_site_called(self):
         """

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -3,20 +3,20 @@ from unittest.mock import patch
 from django.contrib.contenttypes.models import ContentType
 from django.contrib.sites.models import Site
 
-from cms.models import Page, User, PageContent
+from cms.models import Page, PageContent, User
 from cms.test_utils.testcases import CMSTestCase
 from cms.utils.urlutils import admin_reverse
-from django.db.models import QuerySet
-from django.test import override_settings
+
+from djangocms_versioning.constants import PUBLISHED
 
 from djangocms_navigation.constants import SELECT2_CONTENT_OBJECT_URL_NAME
 from djangocms_navigation.test_utils.factories import (
     MenuContentFactory,
-    PageContentFactory, PageContentWithVersionFactory,
+    PageContentFactory,
+    PageContentWithVersionFactory,
 )
 from djangocms_navigation.test_utils.polls.models import Poll, PollContent
 from djangocms_navigation.views import ContentObjectSelect2View
-from djangocms_versioning.constants import PUBLISHED
 
 
 class PreviewViewPermissionTestCases(CMSTestCase):
@@ -222,7 +222,6 @@ class ContentObjectAutoFillTestCases(CMSTestCase):
         expected_json = {"results": [{"text": "example", "id": 1}]}
         self.assertEqual(response.json(), expected_json)
 
-    @override_settings(DJANGOCMS_NAVIGATION_VERSIONING_ENABLED=True)
     def test_with_multiple_versions_distinct_results_returned(self):
         """
         Check that when there are multiple Pages, and each have multiple versions of PageContent, that the returned

--- a/tests/test_views.py
+++ b/tests/test_views.py
@@ -258,8 +258,32 @@ class ContentObjectAutoFillTestCases(CMSTestCase):
         self.assertEqual(response.status_code, 200)
         self.assertEqual(len(results), 2)
         expected = [
-            {"text": str(first_page.page), "id": first_page.page.pk},
-            {"text": str(second_page.page), "id": second_page.page.pk}
+            {"text": "test", "id": first_page.page.pk},
+            {"text": "test2", "id": second_page.page.pk}
+        ]
+        self.assertEqual(results, expected)
+
+    def test_with_pagecontent_in_multiple_languages_english_returned(self):
+        page_contenttype_id = ContentType.objects.get_for_model(Page).id
+        english = PageContentFactory(
+            title="test", menu_title="test", page_title="test", language="en",
+        )
+        # create a non-english page
+        PageContentFactory(
+            title="test", menu_title="test", page_title="test", language="fr",
+        )
+
+        with self.login_user_context(self.superuser):
+            response = self.client.get(
+                self.select2_endpoint,
+                data={"content_type_id": page_contenttype_id, "query": "test"},
+            )
+            results = response.json()["results"]
+
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(len(results), 1)
+        expected = [
+            {"text": "test", "id": english.page.pk},
         ]
         self.assertEqual(results, expected)
 


### PR DESCRIPTION
### Description
Fixes a bug that was causing duplicate objects to be displayed for selection when a user adds a menu item node.

In addition the Page objects returned for selection are filtered by the current site and language.

As part of this, the view has been refactored to simplify the logic used to get data and remove readability by removing nested/excessive conditionals. This includes removing the hardcoded filter on the title for `Page` objects in order to make use of the `navigation_models` attribute on the app config as it was intended. As such, the changes include extensive additional unit tests for the `ContentObjectSelect2View.get_data` method.

I believe that the `get_data` could be refactored further, as some of the implemented functionality is unused outside of tests. However I decided this was out of scope for the current ticket, but is something we could revisit in future.

### Related resources
### Checklist

- [x]  I have opened this pull request against master
- [x]  I have added or modified the tests when changing logic
- [x]  I have followed [the conventional commits guidelines](https://www.conventionalcommits.org/) to add meaningful information into the changelog