### PR TITLE
fix: Navigation nodes with page display edit links in edit mode.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* fix: Navigation nodes with a page attached display edit urls in edit mode
 * feat: When adding a MenuItem the Page objects are filtered by PageUrl slug and path
 
 1.5.1 (2022-08-26)

--- a/djangocms_navigation/cms_menus.py
+++ b/djangocms_navigation/cms_menus.py
@@ -3,7 +3,7 @@ from django.db.models import Q
 
 from cms.cms_menus import CMSMenu as OriginalCMSMenu
 from cms.models import Page
-from cms.toolbar.utils import get_object_preview_url
+from cms.toolbar.utils import get_object_edit_url, get_object_preview_url
 from cms.utils import get_current_site, get_language_from_request
 from menus.base import Menu, Modifier, NavigationNode
 from menus.menu_pool import menu_pool
@@ -85,7 +85,10 @@ class CMSMenu(Menu):
             latest_page_content = get_latest_page_content_for_page_grouper(obj, language)
             # if there is no DRAFT or PUBLISHED version we should use it
             if latest_page_content:
-                return get_object_preview_url(latest_page_content, language=language)
+                if request.toolbar.edit_mode_active:
+                    return get_object_edit_url(latest_page_content, language=language)
+                else:
+                    return get_object_preview_url(latest_page_content, language=language)
             # Otherwise, there is no DRAFT or PUBLISHED version, we shouldn't show a link for
             # ARCHIVED or UNPUBLISHED
             return ""

--- a/tests/test_cms_menus.py
+++ b/tests/test_cms_menus.py
@@ -477,7 +477,7 @@ class CMSMenuWithPagesTestCase(CMSTestCase):
 
     def test_published_page_in_menu_links_in_edit_mode(self):
         """
-        The edit mode should show preview links for any menu items attached to a page
+        The edit mode should show edit links for any menu items attached to a page
         """
         menu_item_pagecontent = factories.PageContentWithVersionFactory(
             language=self.language,
@@ -489,14 +489,14 @@ class CMSMenuWithPagesTestCase(CMSTestCase):
         with self.login_user_context(self.get_superuser()):
             response = self.client.get(self.edit_endpoint)
 
-        expected_preview_endpoint = get_object_preview_url(menu_item_pagecontent, language=self.language)
-        not_expected_edit_endpoint = get_object_edit_url(menu_item_pagecontent, language=self.language)
+        not_expected_preview_endpoint = get_object_preview_url(menu_item_pagecontent, language=self.language)
+        expected_edit_endpoint = get_object_edit_url(menu_item_pagecontent, language=self.language)
         not_expected_live_endpoint = menu_item_pagecontent.get_absolute_url(language=self.language)
         actual_link = self._get_first_navigation_node_link_from_response(response)
 
         self.assertEqual(response.status_code, 200)
-        self.assertIn(expected_preview_endpoint, actual_link)
-        self.assertNotIn(not_expected_edit_endpoint, actual_link)
+        self.assertIn(expected_edit_endpoint, actual_link)
+        self.assertNotIn(not_expected_preview_endpoint, actual_link)
         self.assertNotIn(not_expected_live_endpoint, actual_link)
 
     def test_published_page_in_menu_links_in_preview_mode(self):


### PR DESCRIPTION
Navigation nodes with page attached now display edit urls when in edit mode