### PR TITLE
feat: moving a menu item node requires user confirmation

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Changelog
 
 Unreleased
 ==========
+* feat: display confirmation dialog when moving a menu item node
 
 1.6.2 (2022-09-15)
 ==================

--- a/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
+++ b/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
@@ -230,7 +230,10 @@ Original code found in treebeard-admin.js
                         }
                     });
                 }).bind('mouseup',function () {
-                    if ($targetRow !== null) {
+                    // prompt user to confirm the move
+                    let name = node.node_name()
+                    let confirmMove = confirm(`Are you sure you want to move menu item ${name}?`)
+                    if ($targetRow !== null && confirmMove === true) {
                         target_node = new Node($targetRow[0]);
                         if (target_node.node_id !== node.node_id) {
 

--- a/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
+++ b/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
@@ -231,8 +231,8 @@ Original code found in treebeard-admin.js
                     });
                 }).bind('mouseup',function () {
                     // prompt user to confirm the move
-                    let name = node.node_name()
-                    let confirmMove = confirm(`Are you sure you want to move menu item ${name}?`)
+                    let moveMessage = `${node.elem.parentElement.dataset["moveMessage"]} ${node.node_name()}?`
+                    let confirmMove = confirm(moveMessage)
                     if ($targetRow !== null && confirmMove === true) {
                         target_node = new Node($targetRow[0]);
                         if (target_node.node_id !== node.node_id) {

--- a/djangocms_navigation/templates/djangocms_navigation/admin/tree_change_list_results.html
+++ b/djangocms_navigation/templates/djangocms_navigation/admin/tree_change_list_results.html
@@ -20,7 +20,7 @@ Clone of treebeard tree_change_list_results page, with additional check to allow
                     {% if header.sortable %}</a>{% endif %}</th>{% endfor %}
             </tr>
             </thead>
-            <tbody>
+            <tbody data-move-message="{{ move_node_message }}">
             {% for node_id, parent_id, node_level, children_num, result in results %}
                 <tr id="node-{{ node_id }}-id" class="{% cycle 'row1' 'row2' %}"
                     level="{{ node_level }}" children-num="{{ children_num }}"

--- a/djangocms_navigation/templatetags/navigation_admin_tree.py
+++ b/djangocms_navigation/templatetags/navigation_admin_tree.py
@@ -73,12 +73,17 @@ def result_tree(context, cl, request):
     # should be disabled as this the preview view is readonly
     disable_drag_drop = is_preview_url(request=request)
 
+    # Message defined here so that it is translatable. The title of the menu item is appended to the message in the JS
+    move_node_message = _("Are you sure you want to move menu item")
+
     return {
         'filtered': not check_empty_dict(request.GET),
         'result_hidden_fields': list(result_hidden_fields(cl)),
         'result_headers': headers,
         'results': list(results(cl)),
         'disable_drag_drop': disable_drag_drop,
+        'move_node_message': move_node_message
+
     }
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1182,6 +1182,22 @@ class MenuItemAdminChangeListViewTestCase(CMSTestCase, UsefulAssertsMixin):
         self.assertEqual(_('Toggle expand/collapse all'), link['title'])
         self.assertIn('+', link.string)
 
+    def test_menuitem_move_message(self):
+        """
+        Check that confirmation message displayed when moving a menu item is present on the page via a data attribute on
+        the tbody element
+        """
+        menu_content = factories.MenuContentWithVersionFactory()
+
+        list_url = reverse(
+            "admin:djangocms_navigation_menuitem_list", args=(menu_content.id,)
+        )
+        response = self.client.get(list_url)
+
+        soup = BeautifulSoup(str(response.content), features="lxml")
+        element = soup.find("tbody")
+        self.assertEqual(element.attrs["data-move-message"], "Are you sure you want to move menu item")
+
 
 @override_settings(
     CMS_PERMISSION=True,


### PR DESCRIPTION
Uses javascript confirm function to display a dialog box when a user moves a menu item node.