### PR TITLE
Feature/expanded nodes are stored in the page session so that the structure of the nav tree is retained after editing a menu

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 
 Unreleased
 ==========
+* feat: store a list of expanded nodes in a page session object so after editing a menu the
+previous state is displayed
 
 1.7.0 (2022-09-21)
 ==================

--- a/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
+++ b/djangocms_navigation/static/djangocms_navigation/js/navigation-tree-admin.js
@@ -63,7 +63,7 @@ Original code found in treebeard-admin.js
                     }
                 }).show();
             },
-            // collapse_all() and expand_all() show/hide the node + child nodes AND modifies classes: 
+            // collapse_all() and expand_all() show/hide the node + child nodes AND modifies classes:
             // (In practice these functions are only used with the root node)
             collapse_all: function () {
                 this.$elem.find('a.collapse').removeClass('expanded').addClass('collapsed');
@@ -85,9 +85,20 @@ Original code found in treebeard-admin.js
                     this.expand();
                     // Update classes just for this node:
                     this.$elem.find('a.collapse').removeClass('collapsed').addClass('expanded');
+                    let key = "expanded-" + this.node_id
+                    sessionStorage.setItem(key, this.elem.id)
                 } else {
                     this.collapse();
                     this.$elem.find('a.collapse').removeClass('expanded').addClass('collapsed');
+                    let key = "expanded-" + this.node_id
+                    sessionStorage.removeItem(key)
+                    if (this.has_children()) {
+                        $.each(this.children(), function () {
+                            let child_key = "expanded-" + this.getAttribute("node")
+                            sessionStorage.removeItem(child_key)
+                        })
+
+                    }
                 }
             },
             clone: function () {
@@ -97,6 +108,17 @@ Original code found in treebeard-admin.js
     };
 
     $(document).ready(function () {
+
+        console.log(sessionStorage)
+
+        $.each(sessionStorage, function (key, value) {
+            if (key.startsWith("expanded-")) {
+                var node = $.find('#' + value)[0]
+                node = new Node(node)
+                node.toggle()
+                // need to remove class from children
+            }
+        })
 
         // begin csrf token code
         // Taken from http://docs.djangoproject.com/en/dev/ref/contrib/csrf/#ajax
@@ -334,7 +356,9 @@ Original code found in treebeard-admin.js
         }
 
         $('a.collapse').click(function () {
+            console.log($(this).closest('tr')[0])
             var node = new Node($(this).closest('tr')[0]); // send the DOM node, not jQ
+            console.log(node)
             node.toggle();
             return false;
         });
@@ -344,7 +368,7 @@ Original code found in treebeard-admin.js
             // Get root node:
             let root_node = new Node($.find('tr[level=1]')[0]);
 
-            // Toggle expand / collapse all: 
+            // Toggle expand / collapse all:
             if (!this.hasAttribute('class') || $(this).hasClass('collapsed-all') ) {
                 root_node.expand_all();
                 $(this).addClass('expanded-all').removeClass('collapsed-all').text('-');
@@ -353,7 +377,7 @@ Original code found in treebeard-admin.js
                 $(this).addClass('collapsed-all').removeClass('expanded-all').text('+');
             }
         });
-        
+
         var hash = window.location.hash;
 
         if (hash) {

--- a/djangocms_navigation/templates/djangocms_navigation/admin/tree_change_list_results.html
+++ b/djangocms_navigation/templates/djangocms_navigation/admin/tree_change_list_results.html
@@ -9,7 +9,7 @@ Clone of treebeard tree_change_list_results page, with additional check to allow
 {% endif %}
 {% if results %}
     <div class="results">
-        <table cellspacing="0" id="result_list">
+        <table cellspacing="0" id="result_list" data-menu-content-id="{{ menu_content_id }}">
             <thead>
             <tr>
                 {% for header in result_headers %}

--- a/djangocms_navigation/templatetags/navigation_admin_tree.py
+++ b/djangocms_navigation/templatetags/navigation_admin_tree.py
@@ -82,8 +82,8 @@ def result_tree(context, cl, request):
         'result_headers': headers,
         'results': list(results(cl)),
         'disable_drag_drop': disable_drag_drop,
-        'move_node_message': move_node_message
-
+        'move_node_message': move_node_message,
+        'menu_content_id': context["menu_content"].pk
     }
 
 

--- a/tests/test_admin.py
+++ b/tests/test_admin.py
@@ -1198,6 +1198,22 @@ class MenuItemAdminChangeListViewTestCase(CMSTestCase, UsefulAssertsMixin):
         element = soup.find("tbody")
         self.assertEqual(element.attrs["data-move-message"], "Are you sure you want to move menu item")
 
+    def test_menu_content_id_present(self):
+        """
+        Check that the rendered template includes the menu content id as a data attribute so that it can be accessed by
+        the client side js
+        """
+        menu_content = factories.MenuContentWithVersionFactory()
+        list_url = reverse(
+            "admin:djangocms_navigation_menuitem_list", args=(menu_content.id,)
+        )
+        response = self.client.get(list_url)
+
+        soup = BeautifulSoup(str(response.content), features="lxml")
+        result_list = soup.find(id="result_list")
+
+        self.assertEqual(result_list["data-menu-content-id"], str(menu_content.pk))
+
 
 @override_settings(
     CMS_PERMISSION=True,


### PR DESCRIPTION
Expanded nodes are stored in the page session so that the structure of the nav tree is retained after editing a menu.

Stores a list of node ID's in a JS page session object so that after editing a menu, or deleting a node, the menu is displayed in the same structure as before beginning the change, with the correct nodes expanded. The session object expires when the browser page or tab is closed.