### PR TITLE
fix: display node tree on menu item delete confirmation page

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,8 @@ Changelog
 
 Unreleased
 ==========
+* fix: delete confirmation screen displays all nodes to be deleted, with each node nested
+correctly to match the standard django delete confirmation view
 
 1.8.1 (2022-10-21)
 ==================


### PR DESCRIPTION
Fixes a bug which meant not all child nodes were displayed on the delete confirmation page. Also ensures that the node tree displays items with the correct nesting to reflect their position in the tree.